### PR TITLE
feature: connected Contact Us form to backend route POST /contact-us 

### DIFF
--- a/Backend/Gemfile.lock
+++ b/Backend/Gemfile.lock
@@ -117,6 +117,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.1)
     minitest (5.18.0)
     msgpack (1.7.0)
     net-imap (0.3.4)
@@ -129,6 +130,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.14.3)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     public_suffix (5.0.1)
@@ -183,6 +187,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.2)
+      mini_portile2 (~> 2.8.0)
     sqlite3 (1.6.2-x86_64-linux)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
@@ -212,6 +218,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/Backend/app/controllers/application_controller.rb
+++ b/Backend/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :null_session
   before_action :authorize
+  skip_before_action :authorize, only: [:contact_us]
 
   def encode_token(payload)
     # should store secret in env variable
@@ -67,6 +68,12 @@ class ApplicationController < ActionController::Base
     end
 
     render json: { message: 'Please log in as a donor or as a charity or as an admin' }, status: :unauthorized
+  end
+
+  def contact_us
+    @form_data = params[:application]
+    # render json: @form_data
+    ApplicationMailer.send_contact_form_email(@form_data).deliver
   end
 
 end

--- a/Backend/app/mailers/application_mailer.rb
+++ b/Backend/app/mailers/application_mailer.rb
@@ -1,4 +1,16 @@
 class ApplicationMailer < ActionMailer::Base
   default from: "givehopecharities@gmail.com"
   layout "mailer"
+
+  def send_contact_form_email(form_data)
+    @sender_name = form_data[:name]
+    @sender_email = form_data[:email]
+    @subject = form_data[:subject]
+    @message = form_data[:message]
+    mail(
+      to: @sender_email,
+      bcc: "givehopecharities@gmail.com",
+      subject: "Contact Form: #{form_data[:subject]}"
+    )
+  end
 end

--- a/Backend/app/views/application_mailer/send_contact_form_email.html.erb
+++ b/Backend/app/views/application_mailer/send_contact_form_email.html.erb
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+      <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+    <title></title>
+  </head>
+
+  <body>
+        <p>Hello <%= @sender_name%>,</p>
+
+        <p>Thank you for getting in touch with us! The following message has been sent from the Contact Us form:</p>
+        <ul>
+            <p>Name: <%= @sender_name%></p>
+            <p>Email: <%= @sender_email%></p>
+            <p>Subject: <%= @subject%></p>
+            <p>Message: <br> <%= @message%></p>
+        </ul>
+
+        <p>We will get back to you as soon as possible.</p>
+        <p>Best regards,<br>The Give Hope</p>
+
+        <img src="https://github.com/astronaut-nemo/phase-5-sendgrid-test/blob/main/app/views/user_notifier_mailer/Email%20Banner.png?raw=true"/>
+  </body>
+</html>

--- a/Backend/app/views/donor_notifier_mailer/send_donation_received_email.html.erb
+++ b/Backend/app/views/donor_notifier_mailer/send_donation_received_email.html.erb
@@ -16,7 +16,7 @@
 	<p>Once again, thank you for your support and for choosing to partner with us in our mission. We couldn't do it without donors like you.</p>
 
 	<p>Warm regards,<br>
-	<em>Give Hope</em> and 
+	<em>The Give Hope Team</em> and 
 	<em><%= @charity.name%></em></p>
 
     <img src="https://github.com/astronaut-nemo/phase-5-sendgrid-test/blob/main/app/views/user_notifier_mailer/Email%20Banner.png?raw=true"/>

--- a/Backend/app/views/donor_notifier_mailer/send_donor_signup_email.html.erb
+++ b/Backend/app/views/donor_notifier_mailer/send_donor_signup_email.html.erb
@@ -13,7 +13,7 @@
         <p>You can log into your new account <a src="/">here</a>.</p>
         <p>Thank you for joining us in this important mission.</p>
 
-        <p>Best regards,<br>Give Hope</p>
+        <p>Best regards,<br>The Give Hope Team</p>
 
         <img src="https://github.com/astronaut-nemo/phase-5-sendgrid-test/blob/main/app/views/user_notifier_mailer/Email%20Banner.png?raw=true"/>
     </body>

--- a/Backend/config/routes.rb
+++ b/Backend/config/routes.rb
@@ -53,6 +53,9 @@ Rails.application.routes.draw do
    put '/donations/:id', to: 'donations#update'
    delete '/donations/:id', to: 'donations#destroy'
 
+  #  Application Routes
+  # Contact Us Form Route
+  post "/contact-us", to: 'application#contact_us'
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/client/src/components/ContactUs.jsx
+++ b/client/src/components/ContactUs.jsx
@@ -3,21 +3,44 @@ import "../components/ContactUs.css";
 
 
 const ContactUs = () => {
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [subject, setSubject] = useState("");
-  const [message, setMessage] = useState("");
+  // States
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    subject: "",
+    message: ""
+  })
+
+  // Event Handlers
+  const handleChange = (e) => {
+    const name = e.target.name;
+    const value = e.target.value;
+
+    setFormData({
+      ...formData,
+      [name]: value
+    })
+  }
+  // console.log(formData)
 
   const handleSubmit = (e) => {
     e.preventDefault();
     try {
       // Do something with form data
-      console.log("Form submitted!", name, email, subject, message);
+      fetch("http://localhost:3000/contact-us", {
+        method: "POST",
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData)
+      })
+
       alert("Your message has been sent!");
-      setName("");
-      setEmail("");
-      setSubject("");
-      setMessage("");
+      // Reset the form
+      setFormData({
+          name: "",
+          email: "",
+          subject: "",
+          message: ""
+      });
     } catch (error) {
       console.error("An error occurred:", error);
       alert("There was an error submitting your message. Please try again.");
@@ -72,8 +95,9 @@ const ContactUs = () => {
                 className="form-control  "
                 id="name"
                 placeholder="Name*"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
+                name="name"
+                value={formData.name}
+                onChange={handleChange}
               />
             </div>
             <div className="form-group mt-4 mb-4">
@@ -82,8 +106,9 @@ const ContactUs = () => {
                 className="form-control"
                 id="email"
                 placeholder="Email*"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
+                name="email"
+                value={formData.email}
+                onChange={handleChange}
               />
             </div>
             <div className="form-group mt-4 mb-4">
@@ -92,8 +117,9 @@ const ContactUs = () => {
                 className="form-control"
                 id="subject"
                 placeholder="Subject*"
-                value={subject}
-                onChange={(e) => setSubject(e.target.value)}
+                name="subject"
+                value={formData.subject}
+                onChange={handleChange}
               />
             </div>
             <div className="form-group mt-4 mb-4">
@@ -102,8 +128,9 @@ const ContactUs = () => {
                 id="message"
                 rows="4"
                 placeholder="Message"
-                value={message}
-                onChange={(e) => setMessage(e.target.value)}
+                name="message"
+                value={formData.message}
+                onChange={handleChange}
               ></textarea>
             </div>
             <button type="submit" className="btn btn-primary">


### PR DESCRIPTION
Connected ContactUs form to route POST /contact-us with the ApplicationController#contact_us action. Now, once the ContactUs form is submitted, an email will be sent to the sender and to givehopecharities@gmail.com with the message from the form.
Updated email signature to "The Give Hope Team" for donor emails.